### PR TITLE
[Feat] 포스트 리스트 페이지 추가

### DIFF
--- a/components/Layout/Layout.module.scss
+++ b/components/Layout/Layout.module.scss
@@ -1,3 +1,6 @@
 .main {
-  padding: 0 10vw;
+  padding: 1rem 10vw;
+  max-width: 1000px;
+  align-self: center;
+  margin: 0 auto;
 }

--- a/components/Nav/Nav.module.scss
+++ b/components/Nav/Nav.module.scss
@@ -1,4 +1,5 @@
 .nav {
+  z-index: 1000;
   display: flex;
   justify-content: space-around;
   flex-wrap: wrap;

--- a/components/Pagination/PageButton/PageButton.module.scss
+++ b/components/Pagination/PageButton/PageButton.module.scss
@@ -1,0 +1,22 @@
+.button {
+  display: inline-block;
+  margin-top: 1em;
+  div {
+    border: 1px solid #eee;
+    border-radius: 5px;
+    padding: 0.5em;
+    min-width: 2em;
+    text-align: center;
+    &:hover {
+      background-color: #e5e5e5;
+    }
+  }
+  & + & {
+    margin-left: 5px;
+  }
+}
+
+.active {
+  background-color: #e5e5e5;
+  border-radius: 5px;
+}

--- a/components/Pagination/PageButton/PageButton.tsx
+++ b/components/Pagination/PageButton/PageButton.tsx
@@ -1,0 +1,28 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import classNames from 'classnames';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { ReactNode } from 'react';
+import styles from './PageButton.module.scss';
+
+type PageButtonProps = {
+  href: string,
+  children: ReactNode,
+}
+const PageButton = ({ href, children }: PageButtonProps) => {
+  const { asPath } = useRouter();
+
+  return (
+    <div className={classNames(styles.button, { [styles.active]: asPath === href })}>
+      <Link href={href}>
+        <a>
+          <div>
+            {children}
+          </div>
+        </a>
+      </Link>
+    </div>
+  );
+};
+
+export default PageButton;

--- a/components/Pagination/Pagination.module.scss
+++ b/components/Pagination/Pagination.module.scss
@@ -1,0 +1,5 @@
+.pagination {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+}

--- a/components/Pagination/Pagination.tsx
+++ b/components/Pagination/Pagination.tsx
@@ -1,0 +1,30 @@
+import styles from './Pagination.module.scss';
+import PageButton from './PageButton/PageButton';
+
+type PaginationProps = {
+  path: string,
+  start: number,
+  end: number,
+  prev?: boolean,
+  next?: boolean,
+};
+
+const Pagination = ({
+  path, start, end, prev, next,
+}: PaginationProps) => {
+  const pages = Array(end - start + 1).fill(start).map((value, idx) => value + idx);
+  return (
+    <div className={styles.pagination}>
+      {prev && <PageButton href={`${path}/${start - 1}`}>PREV</PageButton>}
+      {pages.map((page) => <PageButton key={page} href={`${path}/${page}`}>{page}</PageButton>)}
+      {next && <PageButton href={`${path}/${end + 1}`}>NEXT</PageButton>}
+    </div>
+  );
+};
+
+Pagination.defaultProps = {
+  prev: false,
+  next: false,
+};
+
+export default Pagination;

--- a/components/PostPreview/PostPreview.module.scss
+++ b/components/PostPreview/PostPreview.module.scss
@@ -1,0 +1,27 @@
+.preview {
+  p, h2 {
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  & + & {
+    border-top: solid 1px #eee;
+  }
+}
+
+.post {
+  display: inline-block;
+  width: 100%;
+  padding: 1rem;
+}
+
+.withImage {
+  width: calc(100% - 100px);
+}
+
+.image {
+  display: inline-block;
+  width: 100px;
+  height: 100px;
+}

--- a/components/PostPreview/PostPreview.tsx
+++ b/components/PostPreview/PostPreview.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import Link from 'next/link';
+import Image from 'next/image';
+import classNames from 'classnames';
+import styles from './PostPreview.module.scss';
+
+type PostPreviewProps = {
+  title: string,
+  body: string,
+  href: string,
+  imgSrc?: string,
+};
+
+const PostPreview = ({
+  title, body, href, imgSrc,
+}: PostPreviewProps) => (
+  <article className={styles.preview}>
+    <Link href={href}>
+      <a>
+        <div className={classNames(styles.post, { [styles.withImage]: imgSrc })}>
+          <h2>{title}</h2>
+          <p>{body}</p>
+        </div>
+        {imgSrc && <div className={styles.image}><Image src={imgSrc} alt={title} width="100" height="100" /></div>}
+      </a>
+    </Link>
+  </article>
+);
+
+PostPreview.defaultProps = {
+  imgSrc: null,
+};
+
+export default PostPreview;

--- a/data/posts.ts
+++ b/data/posts.ts
@@ -1,0 +1,23 @@
+export type PostType = {
+  userId: number,
+  id: number,
+  title: string,
+  body: string,
+};
+
+export async function getPosts(perPage?: number, page?: number) {
+  const result = await fetch('https://jsonplaceholder.typicode.com/posts');
+  const posts: PostType[] = await result.json();
+
+  if (perPage && page) {
+    const start = (page - 1) * perPage;
+    return posts.slice(start, start + perPage);
+  }
+  return posts;
+}
+
+export async function getPostCount() {
+  const result = await fetch('https://jsonplaceholder.typicode.com/posts');
+  const posts = await result.json();
+  return posts.length;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,15 @@
 module.exports = {
   reactStrictMode: true,
-}
+  images: {
+    domains: ['via.placeholder.com'],
+  },
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/list/1',
+        permanent: true,
+      },
+    ];
+  },
+};

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "classnames": "^2.3.1",
     "next": "12.0.7",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,0 @@
-const Home = () => (
-  <p>Recent posts will be placed here</p>
-);
-
-export default Home;

--- a/pages/list/[page].tsx
+++ b/pages/list/[page].tsx
@@ -1,0 +1,77 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import { useRouter } from 'next/router';
+import Pagination from '../../components/Pagination/Pagination';
+import PostPreview from '../../components/PostPreview/PostPreview';
+import { getPostCount, getPosts, PostType } from '../../data/posts';
+
+const POST_PER_LIST = 5;
+const LIST_PER_PAGE = 10;
+
+type ListProps = {
+  posts: PostType[],
+  pagination: {
+    start: number,
+    end: number,
+    max: number,
+  },
+};
+
+const List = ({ posts, pagination }: ListProps) => {
+  const router = useRouter();
+  const { page } = router.query;
+  const { start, end, max } = pagination;
+
+  return (
+    <section>
+      <h1>Recent Posts</h1>
+      {posts.map(({ id, title, body }) => (
+        <PostPreview
+          key={id}
+          title={title}
+          body={body}
+          href={`/post/${id}`}
+        />
+      ))}
+      <Pagination
+        path="/list"
+        start={start}
+        end={end}
+        prev={Number(page) > LIST_PER_PAGE}
+        next={end < max}
+      />
+    </section>
+  );
+};
+
+export async function getStaticPaths() {
+  const postCount = await getPostCount();
+  let max = Math.floor(postCount / POST_PER_LIST);
+  if (postCount % POST_PER_LIST > 0) max += 1;
+  const pages = Array(max).fill(1).map((value, idx) => value + idx);
+  const paths = pages.map((page) => ({
+    params: { page: String(page) },
+  }));
+  return { paths, fallback: false };
+}
+
+export async function getStaticProps({ params }: any) {
+  const posts = await getPosts(POST_PER_LIST, params.page);
+  const postCount = await getPostCount();
+  let max = Math.floor(postCount / POST_PER_LIST);
+  if (postCount % POST_PER_LIST > 0) max += 1;
+  const start = Math.floor((params.page - 1) / LIST_PER_PAGE) * LIST_PER_PAGE + 1;
+  const end = start + LIST_PER_PAGE - 1;
+  return {
+    props: {
+      posts,
+      pagination: {
+        start,
+        end: end > max ? max : end,
+        max,
+      },
+    },
+    revalidate: 10,
+  };
+}
+
+export default List;

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,6 +723,11 @@ classnames@2.2.6:
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"


### PR DESCRIPTION
# What
## 컴포넌트
- 리스팅용 PostPreview 컴포넌트를 작성하였다.
- 페이지네이션용 PageButton, Pagination 컴포넌트를 작성하였다.
## 페이지
- 블로그에 접속하면 포스트를 최신순으로 볼 수 있는 리스트 페이지를 작성하였다.
# How
- index 페이지를 리스트 페이지로 사용하려 하였으나 Next.js는 file-system based router를 사용하므로 해당 방식은 부적절하다 판단하였고, next.config.js 파일을 수정하여 `/` path를 `/list/1`으로 permanently redirect 시켜주는 방식을 채택했다.
- JSONPlaceholder에서 post의 count를 반환하는 endpoint, post를 page 단위로 받아오는 query를 지원하지 않아 해당 기능을 수행하는 함수를 따로 작성하였다.
# Ref.
- [Next.js - Two Forms of Pre-rendering](https://nextjs.org/learn/basics/data-fetching/two-forms)
- [Next.js - Redirects](https://nextjs.org/docs/api-reference/next.config.js/redirects)
- [페이징(Paging)에 대한 이해 - (1) 페이지 번호를 생성하자.](https://okky.kr/article/282819)

resolves #2 